### PR TITLE
UCJEPS - 8.1 Update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@babel/preset-env": "^7.4.5",
         "@babel/preset-react": "^7.0.0",
         "@babel/register": "^7.4.0",
-        "@ucb-cspace/cspace-ui": "^9.0.1-ucb.4",
+        "@ucb-cspace/cspace-ui": "^10.0.2-ucb.1",
         "babel-loader": "^9.1.2",
         "babel-plugin-dev-expression": "^0.2.1",
         "babel-plugin-istanbul": "^5.1.2",
@@ -2220,13 +2220,12 @@
       }
     },
     "node_modules/@ucb-cspace/cspace-ui": {
-      "version": "9.0.1-ucb.4",
-      "resolved": "https://registry.npmjs.org/@ucb-cspace/cspace-ui/-/cspace-ui-9.0.1-ucb.4.tgz",
-      "integrity": "sha512-xVtcVgMyw8qGe6pS0gu728FCEkFZnD8ldMHZ9pxrBowA3UL1IyiN6VPTWBF4CTZVPtga1rAhNw4Hu6O9TLhEZw==",
+      "version": "10.0.2-ucb.1",
+      "resolved": "https://registry.npmjs.org/@ucb-cspace/cspace-ui/-/cspace-ui-10.0.2-ucb.1.tgz",
+      "integrity": "sha512-rBsX1Rxpqt3ve3DlTyFDj4dW+gGD9xtOjedD69ypPeACT419tKEip4erHi/kzoSV5gkd7i/gOMtRXPy90ZJn3w==",
       "dev": true,
-      "license": "ECL-2.0",
       "dependencies": {
-        "classnames": "^2.2.5",
+        "classnames": "^2.5.1",
         "cspace-client": "^2.0.0",
         "cspace-input": "^2.0.4",
         "cspace-layout": "^2.0.4",
@@ -2234,10 +2233,10 @@
         "history": "^5.0.0",
         "immutable": "^3.8.2",
         "lodash": "^4.17.21",
-        "moment": "^2.21.0",
-        "openseadragon": "^2.4.0",
-        "prop-types": "^15.6.2",
-        "qs": "^6.5.1",
+        "moment": "^2.30.1",
+        "openseadragon": "^2.4.2",
+        "prop-types": "^15.8.1",
+        "qs": "^6.14.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-helmet": "^6.1.0",
@@ -2247,7 +2246,7 @@
         "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",
         "redux": "^4.1.0",
-        "redux-thunk": "^2.1.0",
+        "redux-thunk": "^2.4.2",
         "warning": "^4.0.3"
       }
     },
@@ -10229,13 +10228,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
-      "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cspace-ui-plugin-profile-ucjeps",
-  "version": "3.0.0-rc.2",
+  "version": "4.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cspace-ui-plugin-profile-ucjeps",
-      "version": "3.0.0-rc.2",
+      "version": "4.0.0-rc.1",
       "license": "ECL-2.0",
       "dependencies": {
         "cspace-ui-plugin-ext-annotation": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-profile-ucjeps",
-  "version": "3.0.0-rc.2",
+  "version": "4.0.0-rc.1",
   "description": "University and Jepson Herbaria profile plugin for the CollectionSpace UI",
   "author": "",
   "license": "ECL-2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.4.0",
-    "@ucb-cspace/cspace-ui": "^9.0.1-ucb.4",
+    "@ucb-cspace/cspace-ui": "^10.0.2-ucb.1",
     "babel-loader": "^9.1.2",
     "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-istanbul": "^5.1.2",

--- a/src/plugins/extensions/locality/fields.js
+++ b/src/plugins/extensions/locality/fields.js
@@ -1,3 +1,4 @@
+import { defineMessages } from 'react-intl';
 import { computeDecimalLatLong } from './utils';
 
 export default (configContext) => {
@@ -13,6 +14,12 @@ export default (configContext) => {
     localityGroupList: {
       localityGroup: {
         [config]: {
+          messages: defineMessages({
+            name: {
+              id: 'field.ext.locality.localityGroup.name',
+              defaultMessage: 'Locality',
+            },
+          }),
           compute: computeDecimalLatLong,
         },
         fieldLocCounty: {

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -113,6 +113,14 @@ export default (configContext) => {
         },
         referenceGroupList: {
           referenceGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.collectionobjects_common.referenceGroup.name',
+                  defaultMessage: 'Reference',
+                },
+              }),
+            },
             reference: {
               [config]: {
                 view: {

--- a/src/plugins/recordTypes/collectionobject/forms/collectorLabel.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/collectorLabel.jsx
@@ -1,16 +1,5 @@
 import { defineMessages } from 'react-intl';
 
-const messages = defineMessages({
-  localityGroup: {
-    id: 'field.collectionobjects_naturalhistory.localityGroup.name',
-    defaultMessage: 'Locality',
-  },
-  referenceGroup: {
-    id: 'field.collectionobjects_common.referenceGroup.name',
-    defaultMessage: 'Reference',
-  },
-});
-
 const template = (configContext) => {
   const {
     React,
@@ -64,7 +53,7 @@ const template = (configContext) => {
         </Field>
 
         <Field name="referenceGroupList">
-          <Field name="referenceGroup" labelMessage={messages.referenceGroup}>
+          <Field name="referenceGroup">
             <Field name="reference" />
             <Field name="referenceNote" />
           </Field>
@@ -77,11 +66,7 @@ const template = (configContext) => {
           </Field>
         </Field>
 
-        <Field
-          name="localityGroupList"
-          subpath="ns2:collectionobjects_naturalhistory"
-          labelMessage={messages.localityGroup}
-        >
+        <Field name="localityGroupList" subpath="ns2:collectionobjects_naturalhistory">
           <Field name="localityGroup">
             <Panel>
               <Cols>

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -182,7 +182,7 @@ const template = (configContext) => {
       </Panel>
 
       <Panel name="locality" collapsible collapsed>
-        <CompoundInput name="ns2:collectionobjects_naturalhistory" subpath="">
+        <CompoundInput subpath="ns2:collectionobjects_naturalhistory">
           {extensions.locality.form}
         </CompoundInput>
       </Panel>

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -95,7 +95,6 @@ const template = (configContext) => {
         <Row>
           <Col>
             <Field name="objectCountNumber" subpath="ns2:collectionobjects_naturalhistory" />
-            <Field name="numberOfObjects" />
 
             <Field name="objectCountGroupList">
               <Field name="objectCountGroup">

--- a/src/plugins/recordTypes/collectionobject/forms/index.js
+++ b/src/plugins/recordTypes/collectionobject/forms/index.js
@@ -12,4 +12,10 @@ export default (configContext) => ({
   photo: {
     disabled: true,
   },
+  public: {
+    disabled: true,
+  },
+  timebased: {
+    disabled: true,
+  },
 });

--- a/src/plugins/recordTypes/concept/vocabularies.js
+++ b/src/plugins/recordTypes/concept/vocabularies.js
@@ -1,14 +1,33 @@
 import { defineMessages } from 'react-intl';
 
 export default {
-  associated: {
-    disabled: true,
-  },
   activity: {
     disabled: true,
   },
   material: {
     disabled: true,
+  },
+  associated: {
+    messages: defineMessages({
+      name: {
+        id: 'vocab.concept.associated.name',
+        description: 'The name of the vocabulary.',
+        defaultMessage: 'Associated',
+      },
+      collectionName: {
+        id: 'vocab.concept.associated.collectionName',
+        description: 'The name of a collection of records from the vocabulary.',
+        defaultMessage: 'Associated Concepts',
+      },
+      itemName: {
+        id: 'vocab.concept.associated.itemName',
+        description: 'The name of a record from the vocabulary.',
+        defaultMessage: 'Associated Concept',
+      },
+    }),
+    serviceConfig: {
+      servicePath: 'urn:cspace:name(associated)',
+    },
   },
   label: {
     messages: defineMessages({


### PR DESCRIPTION
Updates to the ucjeps plugin profile for CollectionSpace 8.1. Contains minor updates mostly from our data QA process.

Changes:
* Add associated concept

Fixes:
* Move away from old labelMessage attribute
  * Overriding the `name` message is preferred
* Remove numberOfObjects from CollectionObject default form
  * This was missed in the 8.0 upgrade
* Fix subpath attribute for locality CompoundInput
* Disable public browser and time based media templates
