### PR TITLE
UCJEPS - 8.3 Update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@axe-core/react": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.11.3.tgz",
+      "integrity": "sha512-G7TrxptKNFfrQZ+Iygb8nGx5w8Su0jIjwmtVN/9Jc4G6RumCh1rD3pZRT2NzZKjT70q4BReuWVwEazS3HxFfjg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4",
+        "requestidlecallback": "^0.3.0"
+      }
+    },
     "node_modules/@babel/cli": {
       "version": "7.26.4",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.26.4.tgz",
@@ -2220,12 +2231,14 @@
       }
     },
     "node_modules/@ucb-cspace/cspace-ui": {
-      "version": "10.0.2-ucb.1",
-      "resolved": "https://registry.npmjs.org/@ucb-cspace/cspace-ui/-/cspace-ui-10.0.2-ucb.1.tgz",
-      "integrity": "sha512-rBsX1Rxpqt3ve3DlTyFDj4dW+gGD9xtOjedD69ypPeACT419tKEip4erHi/kzoSV5gkd7i/gOMtRXPy90ZJn3w==",
+      "version": "10.2.0-ucb.1",
+      "resolved": "https://registry.npmjs.org/@ucb-cspace/cspace-ui/-/cspace-ui-10.2.0-ucb.1.tgz",
+      "integrity": "sha512-FQMnQMpvrF0xgCfizgVsa4vzxJ5j+kF11ekta4A1kCjgEy0FZ5Z9hVpR0/b2cC2L0MgeRrC0DjHAcHApflh7dw==",
       "dev": true,
+      "license": "ECL-2.0",
       "dependencies": {
-        "classnames": "^2.5.1",
+        "@axe-core/react": "^4.11.1",
+        "classnames": "^2.2.5",
         "cspace-client": "^2.0.0",
         "cspace-input": "^2.0.4",
         "cspace-layout": "^2.0.4",
@@ -2233,10 +2246,11 @@
         "history": "^5.0.0",
         "immutable": "^3.8.2",
         "lodash": "^4.17.21",
-        "moment": "^2.30.1",
-        "openseadragon": "^2.4.2",
-        "prop-types": "^15.8.1",
-        "qs": "^6.14.0",
+        "moment": "^2.21.0",
+        "openseadragon": "^2.4.0",
+        "p-limit": "^7.1.1",
+        "prop-types": "^15.6.2",
+        "qs": "^6.5.1",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-helmet": "^6.1.0",
@@ -2246,8 +2260,24 @@
         "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",
         "redux": "^4.1.0",
-        "redux-thunk": "^2.4.2",
+        "redux-thunk": "^2.1.0",
         "warning": "^4.0.3"
+      }
+    },
+    "node_modules/@ucb-cspace/cspace-ui/node_modules/p-limit": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -2936,9 +2966,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
-      "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -10877,6 +10907,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -13543,9 +13580,9 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
-      "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cspace-ui-plugin-profile-ucjeps",
-  "version": "4.0.0-rc.2",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cspace-ui-plugin-profile-ucjeps",
-      "version": "4.0.0-rc.2",
+      "version": "4.1.0",
       "license": "ECL-2.0",
       "dependencies": {
         "cspace-ui-plugin-ext-annotation": "^1.0.3",
@@ -24,7 +24,7 @@
         "@babel/preset-env": "^7.4.5",
         "@babel/preset-react": "^7.0.0",
         "@babel/register": "^7.4.0",
-        "@ucb-cspace/cspace-ui": "^10.0.2-ucb.1",
+        "@ucb-cspace/cspace-ui": "^10.2.0-ucb.1",
         "babel-loader": "^9.1.2",
         "babel-plugin-dev-expression": "^0.2.1",
         "babel-plugin-istanbul": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
     "test": "cross-env NODE_ENV=test karma start --singleRun=true"
   },
   "dependencies": {
+    "cspace-ui-plugin-ext-annotation": "^1.0.3",
     "cspace-ui-plugin-ext-ucbnh-collectionobject": "^2.0.1",
     "cspace-ui-plugin-ext-ucbnh-loanin": "^1.0.0",
     "cspace-ui-plugin-ext-ucbnh-loanout": "^1.0.0",
     "cspace-ui-plugin-ext-ucbnh-organization": "^0.0.1",
     "cspace-ui-plugin-ext-ucbnh-taxon": "^0.0.1",
     "cspace-ui-plugin-record-taxon": "^2.0.3",
-    "cspace-ui-plugin-ext-annotation": "^1.0.3",
     "react-intl": "^2.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-profile-ucjeps",
-  "version": "4.0.0-rc.2",
+  "version": "4.1.0",
   "description": "University and Jepson Herbaria profile plugin for the CollectionSpace UI",
   "author": "",
   "license": "ECL-2.0",
@@ -55,7 +55,7 @@
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.4.0",
-    "@ucb-cspace/cspace-ui": "^10.0.2-ucb.1",
+    "@ucb-cspace/cspace-ui": "^10.2.0-ucb.1",
     "babel-loader": "^9.1.2",
     "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-istanbul": "^5.1.2",


### PR DESCRIPTION
Updates to the ucjeps plugin profile for CollectionSpace 8.3

Dependency:
https://github.com/cspace-deployment/cspace-ui.js/pull/72 should be first merged and published to npmjs. 

When that is done please let me know, so that I do a `npm install --save-dev @ucb-cspace/cspace-ui@10.2.0-ucb.1`. That will update the package-lock.json with the correct resolved URL and integrity hash.

Tagging @lkvoong as a reviewer.